### PR TITLE
adding extra TOC item functionality

### DIFF
--- a/docs/demochapter1/index.md
+++ b/docs/demochapter1/index.md
@@ -3,6 +3,7 @@
 A sample chapter, there's no content here, just a placeholder to demo the sidebar.
 
 ```{toctree}
+:expand_sections:
 subchapter1a/index.md
 subchapter1b/index.md
 chapterpage1.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,13 @@ A test book theme
 
 ```{toctree}
 :maxdepth: 1
+:caption: Main docs
 layout
 notebooks
+```
+```{toctree}
+:divider:
+:caption: Reference items
 demochapter1/index
 limits
 ```

--- a/docs/layout.ipynb
+++ b/docs/layout.ipynb
@@ -159,11 +159,28 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Controlling the left table of contents\n",
+    "\n",
+    "You can control some elements of the left table of contents. Here are the main features:\n",
+    "\n",
+    "### Expand sections of your TOC\n",
+    "\n",
+    "To make all sub-pages of the left Table of Contents expanded, add `:expand_sections:` to the\n",
+    "`toctree` for that section.\n",
+    "\n",
+    "### Add a header to your TOC\n",
+    "\n",
+    "If you'd like to add a header above a section of TOC links, use `:caption: My header text`\n",
+    "in your `toctree` directive for that section.\n",
+    "\n",
+    "### Add a divider to your TOC\n",
+    "\n",
+    "If you'd like to add a divider above a section of TOC links, use `:divider:`\n",
+    "in your `toctree` directive for that section."
+   ]
   }
  ],
  "metadata": {

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -2,11 +2,18 @@
 from pathlib import Path
 import docutils
 from myst_nb.parser import CellNode
+from docutils.parsers.rst import directives
 from sphinx.util import logging
+from sphinx.directives.other import TocTree
 import sass
 
 __version__ = "0.0.1dev0"
 SPHINX_LOGGER = logging.getLogger(__name__)
+EXTRA_TOC_OPTIONS = {
+    "expand_sections": directives.flag,
+    "caption": directives.unchanged_required,
+    "divider": directives.flag,
+}
 
 
 def get_html_theme_path():
@@ -18,6 +25,28 @@ def get_html_theme_path():
 def add_static_path(app):
     static_path = Path(__file__).parent.joinpath("static").absolute()
     app.config.html_static_path.append(str(static_path))
+
+
+def find_url_relative_to_root(pagename, relative_page, path_docs_source):
+    """Given the current page (pagename), a relative page to it (relative_page),
+    and a path to the docs source, return the path to `relative_page`, but now relative
+    to the docs source (since this is what keys in Sphinx tend to use).
+    """
+    # In this case, the relative_page is the same as the pagename
+    if relative_page == "":
+        relative_page = Path(Path(pagename).name)
+
+    # Convert everything to paths for use later
+    path_rel = Path(relative_page).with_suffix("")
+    path_parent = Path(pagename)  # pagename is relative to docs root
+    source_dir = Path(path_docs_source)
+    # This should be the path to `relative_page`, relative to `pagename`
+    path_rel_from_page_dir = source_dir.joinpath(
+        path_parent.parent.joinpath(path_rel.parent)
+    )
+    path_from_page_dir = path_rel_from_page_dir.resolve()
+    page_rel_root = path_from_page_dir.relative_to(source_dir).joinpath(path_rel.name)
+    return page_rel_root
 
 
 def add_to_context(app, pagename, templatename, context, doctree):
@@ -39,6 +68,15 @@ def add_to_context(app, pagename, templatename, context, doctree):
     def nav_to_html_list(nav, level=1, include_item_names=False):
         if len(nav) == 0:
             return ""
+        # Lists of pages where we want to trigger extra TOC behavior
+        extra_toc = app.env.jb_extra_toc_info
+        # And a function we'll use to parse it
+        def lookup_extra_toc(pagename, extra_toc_list, kind="parent"):
+            for first_child_page, parent_page, val in extra_toc_list:
+                lookup_page = first_child_page if kind == "child" else parent_page
+                if str(pagename) == lookup_page:
+                    return val
+
         ul = [f'<ul class="nav sidenav_l{level}">']
         # If we don't include parents, next `ul` should be the same level
         next_level = level + 1 if include_item_names else level
@@ -46,6 +84,23 @@ def add_to_context(app, pagename, templatename, context, doctree):
             # If we're not rendering title names and have no children, skip
             if (child is None) or not (include_item_names or child["children"]):
                 continue
+
+            # Add captions and dividers if so-given
+            page_rel_root = find_url_relative_to_root(
+                pagename, child["url"], app.srcdir
+            )
+            divider = lookup_extra_toc(page_rel_root, extra_toc["divider"], "child")
+            caption = lookup_extra_toc(page_rel_root, extra_toc["caption"], "child")
+            if any((divider, caption)):
+                ul.append('<li class="sidebar-special">')
+                if divider:
+                    ul.append("<hr />")
+                if caption:
+                    # TODO: whenever pydata-sphinx-theme gets support for captions, we should just use that and remove this
+                    ul.append(f'<p class="sidebar-caption">{caption}</p>')
+                ul.append("</li>")
+
+            # Now begin rendering the links
             active = "active" if child["active"] else ""
             ul.append("  " + f'<li class="{active}">')
             # Render links for the top-level names if we wish
@@ -53,6 +108,14 @@ def add_to_context(app, pagename, templatename, context, doctree):
                 ul.append(
                     "  " * 2 + f'<a href="{ child["url"] }">{ child["title"] }</a>'
                 )
+
+            # Check whether we should expand children if it was given in the toctree
+            if child["children"]:
+                is_expanded = lookup_extra_toc(
+                    page_rel_root, extra_toc["expand_sections"], kind="parent"
+                )
+                if is_expanded:
+                    active = True
 
             # Render HTML lists for children if we're on an active section
             if active and child["children"]:
@@ -113,6 +176,27 @@ def compile_scss():
     path_css_folder.joinpath("jupyterbook.css").write_text(css)
 
 
+class NewTocTree(TocTree):
+    newtoctree_spec = TocTree.option_spec.copy()
+    newtoctree_spec.update(EXTRA_TOC_OPTIONS)
+    option_spec = newtoctree_spec
+
+    def run(self):
+        # Check for special TocTree options that we'll use but must be removed
+        for key in EXTRA_TOC_OPTIONS:
+            if key in self.options:
+                val = self.options.pop(key)
+                if val is None:
+                    val = True
+                first_toc_page = str(Path(self.content[0]).with_suffix(""))
+                parent_page = self.env.docname
+                self.env.jb_extra_toc_info[key].append(
+                    (first_toc_page, parent_page, val)
+                )
+        msg_nodes = super().run()
+        return msg_nodes
+
+
 def setup(app):
     compile_scss()
 
@@ -122,3 +206,5 @@ def setup(app):
     app.connect("builder-inited", add_static_path)
     app.add_html_theme("sphinx_book_theme", get_html_theme_path())
     app.connect("html-page-context", add_to_context)
+    directives.register_directive("toctree", NewTocTree)
+    app.env.jb_extra_toc_info = {key: [] for key in EXTRA_TOC_OPTIONS.keys()}

--- a/sphinx_book_theme/static/jupyterbook.css
+++ b/sphinx_book_theme/static/jupyterbook.css
@@ -181,6 +181,10 @@ div.top {
     overflow: hidden;
     position: relative;
     padding-top: 0; }
+  .bd-sidebar p.sidebar-caption {
+    margin-bottom: 0;
+    font-weight: bold;
+    font-size: 1.1em; }
 
 @media (max-width: 768px) {
   .bd-sidebar {

--- a/sphinx_book_theme/static/jupyterbook.scss
+++ b/sphinx_book_theme/static/jupyterbook.scss
@@ -269,6 +269,12 @@ div.top {
         position: relative;
         padding-top: 0;
     }
+
+    p.sidebar-caption {
+        margin-bottom: 0;
+        font-weight: bold;
+        font-size: 1.1em;
+    }
 }
 
 @media (max-width: 768px) {

--- a/sphinx_book_theme/theme.conf
+++ b/sphinx_book_theme/theme.conf
@@ -7,3 +7,4 @@ pygments_style = tango
 single_page = False
 binder_config = {}
 sidebar_footer_text = Theme by the <a href="https://ebp.jupyterbook.org">Executable Book Project</a>
+expand_toc_sections = []


### PR DESCRIPTION
This implements the ability to control some extra things in the left TOC using options in the `toctree` directive. It is slightly less-hacky than #11 but still a bit hacky :-)

Basically, we override the base TocTree directive, check it for a few extra options that we support, and then store them for use later when rendering the HTML. We also store the page on which the TOC was listed, as well as the first item of the TOCtree.

Then, when the sidebar HTML is rendered, we check each child and see if it was stored when a toctree special option was called. Here's the behavior that we currently support:

* If `:expand_sections:` is given in a toctree directive, then the children of the *parent page* will always be shown in the left TOC
* If `:divider:` is given, then a horizontal rule is placed before the *first item* of the toctree directive.
* If `:header:` is given, then a header is placed before the *first item* of the toctree directive.

I'm curious what @chrisjsewell thinks about this one...it's a little bit tricky but I think a bit cleaner than having people put things in the `toctree` content itself.
