### PR TITLE
Showing the TOC

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,12 +9,17 @@ It relies on [Bootstrap 4](https://getbootstrap.com/docs/4.0/getting-started/int
 via the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/) for its base
 structure and configuration.
 
+## Site contents
+
 ```{toctree}
 :maxdepth: 1
 :caption: Main docs
 Page elements and configuration <layout>
 notebooks
 ```
+
+## Reference pages
+
 ```{toctree}
 :divider:
 :caption: Reference items

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -51,8 +51,10 @@ def find_url_relative_to_root(pagename, relative_page, path_docs_source):
 
 
 def add_to_context(app, pagename, templatename, context, doctree):
-    def shrink_if_sidebar():
-        out = ""
+    def show_if_no_sidebar():
+        # By default we'll show, unless there are sidebar items
+        out = "show"
+        # Check for sidebar items in this doctree
         if doctree is not None:
             sidebar_elements = doctree.traverse(docutils.nodes.sidebar)
             cell_containers = list(doctree.traverse(CellNode))
@@ -60,10 +62,11 @@ def add_to_context(app, pagename, templatename, context, doctree):
                 cl
                 for cell in cell_containers
                 for cl in cell.attributes["classes"]
-                if "tag_popout" == cl
+                if any(ii == cl for ii in ["tag_popout", "tag_sidebar"])
             ]
+            # If we found sidebar elements, then we won't show
             if any(len(ii) > 0 for ii in [sidebar_elements, popout_tags]):
-                out = "col-xl-9"
+                out = ""
         return out
 
     def nav_to_html_list(nav, level=1, include_item_names=False):
@@ -138,7 +141,7 @@ def add_to_context(app, pagename, templatename, context, doctree):
         ul = "\n".join(ul)
         return ul
 
-    context["shrink_if_sidebar"] = shrink_if_sidebar
+    context["show_if_no_sidebar"] = show_if_no_sidebar
     context["nav_to_html_list"] = nav_to_html_list
 
 

--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -4,20 +4,20 @@
 
 {% block docs_sidebar %}
 {% if theme_single_page != True %}
-<div class="col-12 col-md-3 col-xl-3 bd-sidebar site-navigation show" id="site-navigation">
+<div class="col-12 col-md-3 bd-sidebar site-navigation show" id="site-navigation">
     {% include "sidebar.html" %}
 </div>    
 {%- endif %}
 {% endblock %}
 
 {% block docs_main %}
-<main class="col py-md-3 pl-md-5 pr-0 bd-content overflow-auto" role="main">
+<main class="col py-md-3 pl-md-5 bd-content overflow-auto" role="main">
     {% block docs_body %}
     {% if theme_single_page != True %}
       {% include "topbar.html" %}
     {% endif %}
     <div id="main-content" class="row">
-        <div class="col-12 col-md-9 col-xl-7">
+        <div class="col-12 col-md-9 col-xxl-7">
         {{ super() }}
         </div>
     </div>

--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -4,7 +4,7 @@
 
 {% block docs_sidebar %}
 {% if theme_single_page != True %}
-<div class="col-12 col-md-3 col-xl-3 bd-sidebar show" id="site-navigation">
+<div class="col-12 col-md-3 col-xl-3 bd-sidebar site-navigation show" id="site-navigation">
     {% include "sidebar.html" %}
 </div>    
 {%- endif %}
@@ -17,7 +17,7 @@
       {% include "topbar.html" %}
     {% endif %}
     <div id="main-content" class="row">
-        <div class="col-12 {{ shrink_if_sidebar() }}">
+        <div class="col-12 col-md-9 col-xl-7">
         {{ super() }}
         </div>
     </div>
@@ -35,13 +35,6 @@
 {% endblock %}
 
 {% block docs_navbar %}
-<div class='top'>
-<button id="navbar-toggler" class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navigation" aria-controls="navbar-menu" aria-expanded="true" aria-label="Toggle navigation" aria-controls="site-navigation">
-    <i class="fas fa-bars"></i>
-    <i class="fas fa-arrow-left"></i>
-    <i class="fas fa-arrow-up"></i>
-</button>
-</div>
 {%- endblock %}
 
 {%- block footer %}

--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -32,9 +32,6 @@
 {% endblock %}
 
 {% block docs_toc %}
-<div class="d-none d-xl-block col-xl-2 bd-toc">
-    {%- include "docs-toc.html" %}
-</div>
 {% endblock %}
 
 {% block docs_navbar %}

--- a/sphinx_book_theme/static/jupyterbook.css
+++ b/sphinx_book_theme/static/jupyterbook.css
@@ -112,7 +112,11 @@ dl.footnote dd p {
   padding-top: .75em;
   padding-bottom: .75em;
   margin-bottom: 1em;
-  background-color: white; }
+  background-color: white;
+  height: 3em; }
+  .topbar button.navbar-toggler, .topbar .download-buttons-dropdown {
+    float: left;
+    height: 100%; }
   .topbar button.topbarbtn {
     margin: 0 .2em;
     background-color: #5a5a5a; }
@@ -188,7 +192,16 @@ div.top {
 .bd-toc {
   top: 0px !important;
   padding-top: 0px !important;
+  height: 3em;
+  overflow-y: auto;
+  right: 0;
   z-index: 999; }
+  .bd-toc nav {
+    opacity: .5;
+    height: 2em; }
+  .bd-toc:hover nav {
+    opacity: 1;
+    height: auto; }
   .bd-toc .tocsection {
     padding-top: 1.5rem; }
     .bd-toc .tocsection .bd-toc nav {

--- a/sphinx_book_theme/static/jupyterbook.css
+++ b/sphinx_book_theme/static/jupyterbook.css
@@ -4,9 +4,6 @@
 /*********************************************
 * Whole page *
 *********************************************/
-.container-fluid {
-  max-width: 1450px; }
-
 body {
   padding-top: 0px !important; }
   body img {
@@ -15,10 +12,23 @@ body {
 /*********************************************
 * Main body *
 *********************************************/
+@media (min-width: 1500px) {
+  .col-xxl-7 {
+    flex: 0 0 58.33333% !important;
+    max-width: 58.33333% !important;
+    position: relative !important;
+    width: 100% !important;
+    padding-right: 15px !important;
+    padding-left: 15px !important; } }
+
+@media (max-width: 1500px) {
+  div.bd-sidebar.collapse:not(.show) + main.bd-content {
+    flex: 0 0 100%;
+    max-width: 100%; } }
+
 main.bd-content {
   padding-top: 3.5em !important;
-  padding-bottom: 0px !important;
-  overflow-y: hidden !important; }
+  padding-bottom: 0px !important; }
 
 main a.headerlink {
   opacity: 0;
@@ -32,7 +42,8 @@ main h1:hover a.headerlink, main h2:hover a.headerlink, main h3:hover a.headerli
   opacity: 1; }
 
 main div.section {
-  padding-right: 1em; }
+  padding-right: 1em;
+  overflow: visible !important; }
 
 main span.eqno {
   float: right;
@@ -41,14 +52,6 @@ main span.eqno {
 
 main div.section ul p, main div.section ol p {
   margin-bottom: 0; }
-
-:target::before {
-  display: block;
-  content: " ";
-  margin-top: -71px;
-  height: 71px;
-  visibility: hidden;
-  pointer-events: none; }
 
 div.cell div.cell_output {
   padding-right: 0; }
@@ -109,8 +112,7 @@ dl.footnote dd p {
 * Top Bar *
 *********************************************/
 .topbar {
-  max-width: 1450px;
-  margin: 0em auto 1em auto;
+  margin: 0em auto 1em auto !important;
   padding-top: .75em;
   padding-bottom: .75em;
   background-color: white;
@@ -175,13 +177,13 @@ button.topbarbtn img {
     opacity: 0;
     transform: rotate(-180deg) scale(0.5); }
 
-@media (max-width: 576px) {
+@media (max-width: 768px) {
   #navbar-toggler i.fa-arrow-up {
     display: inherit; }
   #navbar-toggler i.fa-arrow-left {
     display: none; } }
 
-@media (min-width: 576px) {
+@media (min-width: 768px) {
   #navbar-toggler i.fa-arrow-up {
     display: none; }
   #navbar-toggler i.fa-arrow-left {
@@ -200,7 +202,7 @@ button.topbarbtn img {
   .bd-toc nav {
     opacity: 0;
     transition: opacity 0.2s ease; }
-  @media (min-width: 1200px) {
+  @media (min-width: 1500px) {
     .bd-toc {
       height: auto !important; }
       .bd-toc nav {
@@ -210,8 +212,9 @@ button.topbarbtn img {
     .bd-toc:hover nav, .bd-toc.show nav {
       opacity: 1; }
   .bd-toc .tocsection {
-    padding-top: .5rem;
-    padding-bottom: .5rem; }
+    padding: .5rem 0 .5rem 1rem !important; }
+  .bd-toc .toc-entry a {
+    padding: .125rem 1rem !important; }
 
 /*********************************************
 * Left Nav Bar *
@@ -245,7 +248,7 @@ button.topbarbtn img {
     font-weight: bold;
     font-size: 1.1em; }
 
-.site-navigation {
+.site-navigation, .site-navigation.collapsing {
   transition: flex .2s ease 0s, height .35s ease, opacity 0.2s ease; }
 
 @media (max-width: 768px) {
@@ -364,7 +367,7 @@ nav.bd-links {
       flex: 0 0 25%;
       max-width: 25%;
       height: auto !important; }
-      div.topbar .bd-toc > nav, div.topbar .bd-toc > nav > nav {
+      div.topbar .bd-toc nav, div.topbar .bd-toc nav > ul.nav, div.topbar .bd-toc nav > ul.nav > li > ul.nav {
         opacity: 1;
         display: block; }
       div.topbar .bd-toc .nav-link.active {

--- a/sphinx_book_theme/static/jupyterbook.css
+++ b/sphinx_book_theme/static/jupyterbook.css
@@ -16,7 +16,7 @@ body {
 * Main body *
 *********************************************/
 main.bd-content {
-  padding-top: 0px !important;
+  padding-top: 3.5em !important;
   padding-bottom: 0px !important;
   overflow-y: hidden !important; }
 
@@ -57,7 +57,7 @@ div.cell.tag_output_scroll div.cell_output {
   max-height: 24em;
   overflow-y: auto; }
 
-@media (min-width: 992px) {
+@media (min-width: 768px) {
   div.cell.tag_popout, div.cell.tag_sidebar, div.sidebar {
     float: right;
     clear: right;
@@ -74,7 +74,7 @@ div.cell.tag_output_scroll div.cell_output {
     padding-left: 0;
     margin-bottom: 0; } }
 
-@media (max-width: 992px) {
+@media (max-width: 768px) {
   div.cell.tag_popout, div.cell.tag_sidebar, div.sidebar {
     border-left: 3px solid #c3c3c3;
     margin: 1em;
@@ -109,17 +109,28 @@ dl.footnote dd p {
 * Top Bar *
 *********************************************/
 .topbar {
+  max-width: 1450px;
+  margin: 0em auto 1em auto;
   padding-top: .75em;
   padding-bottom: .75em;
-  margin-bottom: 1em;
   background-color: white;
-  height: 3em; }
-  .topbar button.navbar-toggler, .topbar .download-buttons-dropdown {
+  height: 4em;
+  transition: left .2s; }
+  .topbar > div {
+    height: 2.5em;
+    top: 0px; }
+  .topbar .topbar-main button.navbar-toggler, .topbar .topbar-main .download-buttons-dropdown {
     float: left;
     height: 100%; }
-  .topbar button.topbarbtn {
+  .topbar .topbar-main button.topbarbtn {
     margin: 0 .2em;
     background-color: #5a5a5a; }
+
+.bd-topbar-whitespace {
+  padding-right: none; }
+  @media (max-width: 768px) {
+    .bd-topbar-whitespace {
+      display: none; } }
 
 div.download-buttons-dropdown div.download-buttons {
   display: none;
@@ -164,48 +175,43 @@ button.topbarbtn img {
     opacity: 0;
     transform: rotate(-180deg) scale(0.5); }
 
-@media (max-width: 768px) {
+@media (max-width: 576px) {
   #navbar-toggler i.fa-arrow-up {
     display: inherit; }
   #navbar-toggler i.fa-arrow-left {
     display: none; } }
 
-@media (min-width: 768px) {
+@media (min-width: 576px) {
   #navbar-toggler i.fa-arrow-up {
     display: none; }
   #navbar-toggler i.fa-arrow-left {
     display: inherit; } }
 
-div.top {
-  display: none; }
-
-@media (max-width: 768px) {
-  div.top {
-    height: 3em;
-    display: block; }
-  main button.navbar-toggler {
-    display: none; } }
-
 /*********************************************
 * Table of Contents *
 *********************************************/
 .bd-toc {
-  top: 0px !important;
-  padding-top: 0px !important;
-  height: 3em;
-  overflow-y: auto;
+  padding: 0px !important;
+  overflow-y: hidden !important;
+  background: white;
   right: 0;
-  z-index: 999; }
+  z-index: 999;
+  transition: height .35s ease; }
   .bd-toc nav {
-    opacity: .5;
-    height: 2em; }
-  .bd-toc:hover nav {
-    opacity: 1;
-    height: auto; }
+    opacity: 0;
+    transition: opacity 0.2s ease; }
+  @media (min-width: 1200px) {
+    .bd-toc {
+      height: auto !important; }
+      .bd-toc nav {
+        opacity: 1; } }
+  .bd-toc:hover, .bd-toc.show {
+    height: auto !important; }
+    .bd-toc:hover nav, .bd-toc.show nav {
+      opacity: 1; }
   .bd-toc .tocsection {
-    padding-top: 1.5rem; }
-    .bd-toc .tocsection .bd-toc nav {
-      background-color: white; }
+    padding-top: .5rem;
+    padding-bottom: .5rem; }
 
 /*********************************************
 * Left Nav Bar *
@@ -213,10 +219,11 @@ div.top {
 .bd-sidebar {
   top: 0px !important;
   overflow-y: auto;
-  opacity: 0.6;
   scrollbar-width: thin;
-  height: 100vh !important;
-  transition: flex .2s ease 0s, height .35s ease, opacity 0.2s ease; }
+  height: 100vh !important; }
+  @media (min-width: 768px) {
+    .bd-sidebar {
+      opacity: 0.6; } }
   .bd-sidebar:hover {
     opacity: 1; }
   .bd-sidebar h1.site-logo {
@@ -228,8 +235,6 @@ div.top {
     text-align: center;
     font-size: .9em;
     padding-top: .5em; }
-  .bd-sidebar.collapse:not(.show) {
-    display: none; }
   .bd-sidebar.collapsing {
     border: none;
     overflow: hidden;
@@ -240,7 +245,19 @@ div.top {
     font-weight: bold;
     font-size: 1.1em; }
 
+.site-navigation {
+  transition: flex .2s ease 0s, height .35s ease, opacity 0.2s ease; }
+
 @media (max-width: 768px) {
+  #site-navigation {
+    position: fixed;
+    margin-top: 3.5em;
+    z-index: 2000;
+    background: white; } }
+
+@media (max-width: 768px) {
+  div#main-content {
+    margin-top: 3.5em; }
   .bd-sidebar {
     height: 60vh !important;
     border-bottom: 3px solid #c3c3c3; }
@@ -248,7 +265,9 @@ div.top {
       height: 0px !important; } }
 
 @media (min-width: 768px) {
-  #site-navigation.collapsing {
+  .bd-sidebar {
+    z-index: 2000 !important; }
+  .site-navigation.collapsing {
     flex: 0 0 0px;
     padding: 0; } }
 
@@ -309,10 +328,9 @@ nav.bd-links {
     position: relative;
     border-left: none;
     padding-left: 0; }
-  div#main-content {
-    margin-top: 5em;
-    width: 66% !important;
-    max-width: 66% !important; }
+  .bd-content div#main-content > div {
+    flex: 0 0 75%;
+    max-width: 75%; }
   h1, h2, h3, h4 {
     break-after: avoid; }
   table {
@@ -334,5 +352,23 @@ nav.bd-links {
     border: none; }
   div.container {
     min-width: 50% !important; }
-  div.bd-sidebar, div.prev-next-bottom, div.topbar, div.bd-toc {
-    display: none; } }
+  div.bd-sidebar, div.prev-next-bottom {
+    display: none; }
+  div.topbar {
+    height: 0;
+    padding: 0;
+    position: inherit; }
+    div.topbar div.topbar-main {
+      opacity: 0; }
+    div.topbar .bd-toc {
+      flex: 0 0 25%;
+      max-width: 25%;
+      height: auto !important; }
+      div.topbar .bd-toc > nav, div.topbar .bd-toc > nav > nav {
+        opacity: 1;
+        display: block; }
+      div.topbar .bd-toc .nav-link.active {
+        font-weight: inherit;
+        color: inherit;
+        background-color: inherit;
+        border-left: inherit; } }

--- a/sphinx_book_theme/static/jupyterbook.scss
+++ b/sphinx_book_theme/static/jupyterbook.scss
@@ -2,6 +2,7 @@
 * Variables *
 *********************************************/
 // Breakpoints from Bootstrap: https://getbootstrap.com/docs/4.1/layout/overview/#responsive-breakpoints
+$breakpoint-xxl: 1500px;  // Custom one
 $breakpoint-xl: 1200px;
 $breakpoint-lg: 992px;
 $breakpoint-md: 768px;
@@ -11,12 +12,7 @@ $breakpoint-sm: 576px;
 * Whole page *
 *********************************************/
 
-$content-max-width: 1450px;
 $topbar-height: 3.5em;
-
-.container-fluid {
-    max-width: $content-max-width;
-}
 
 body {
     padding-top: 0px !important;
@@ -29,11 +25,30 @@ body {
 * Main body *
 *********************************************/
 
+// Custom XXL breakpoint
+@media (min-width: $breakpoint-xxl) {
+    .col-xxl-7 {
+        flex: 0 0 58.33333% !important;
+        max-width: 58.33333% !important;
+        position: relative !important;
+        width: 100% !important;
+        padding-right: 15px !important;
+        padding-left: 15px !important;
+    }
+}
+
+// If the sidebar is collapsed, our main content should expand fully
+div.bd-sidebar.collapse:not(.show) + main.bd-content {
+    @media (max-width: $breakpoint-xxl) {
+        flex: 0 0 100%;
+        max-width: 100%;    
+    }
+}
+
 main {
     &.bd-content {
         padding-top: $topbar-height !important;
         padding-bottom: 0px !important;
-        overflow-y: hidden !important;
     }
 
     a.headerlink {
@@ -55,6 +70,7 @@ main {
 
     div.section {
         padding-right: 1em;
+        overflow: visible !important;  // So that sidebars don't cause a scroll
     }
 
     // Math equations
@@ -70,15 +86,6 @@ main {
             margin-bottom: 0;
         }   
     }
-}
-
-:target::before {
-    display: block;
-    content: " ";
-    margin-top: -71px;
-    height: 71px;
-    visibility: hidden;
-    pointer-events: none;
 }
 
 // Cell-specific controls
@@ -173,8 +180,7 @@ dl.footnote {
 * Top Bar *
 *********************************************/
 .topbar {
-    max-width: $content-max-width;
-    margin: 0em auto 1em auto;
+    margin: 0em auto 1em auto !important;
     padding-top: .75em;
     padding-bottom: .75em;
     background-color: white;
@@ -272,7 +278,7 @@ button.topbarbtn img {
 }
 
 
-@media (max-width: $breakpoint-sm) {
+@media (max-width: $breakpoint-md) {
     #navbar-toggler {
         i.fa-arrow-up {
             display: inherit;
@@ -284,7 +290,7 @@ button.topbarbtn img {
     }
 }
 
-@media (min-width: $breakpoint-sm) {
+@media (min-width: $breakpoint-md) {
     #navbar-toggler {
         i.fa-arrow-up {
             display: none;
@@ -315,7 +321,7 @@ button.topbarbtn img {
     }
 
     // On really wide screens, we always show the nav
-    @media (min-width: 1200px) {
+    @media (min-width: $breakpoint-xxl) {
         height: auto !important;
         nav {
             opacity: 1;
@@ -331,8 +337,11 @@ button.topbarbtn img {
     }
 
     .tocsection {
-        padding-top: .5rem;
-        padding-bottom: .5rem;
+        padding: .5rem 0 .5rem 1rem !important
+    }
+
+    .toc-entry a {
+        padding: .125rem 1rem !important;
     }
 }
 
@@ -345,7 +354,7 @@ button.topbarbtn img {
     scrollbar-width: thin;
     height: 100vh !important;
 
-    @media (min-width: 768px) {
+    @media (min-width: $breakpoint-md) {
         opacity: 0.6;
     }
     
@@ -380,7 +389,7 @@ button.topbarbtn img {
     }
 }
 
-.site-navigation {
+.site-navigation, .site-navigation.collapsing {
     transition: flex .2s ease 0s, height .35s ease, opacity 0.2s ease;
 }
 
@@ -568,7 +577,7 @@ nav.bd-links {
             max-width: 25%;
             height: auto !important;
             // All 1st and 2nd items should be displayed
-            > nav, > nav > nav {
+            nav, nav > ul.nav, nav > ul.nav > li > ul.nav {
                 opacity: 1;
                 display: block;
             }

--- a/sphinx_book_theme/static/jupyterbook.scss
+++ b/sphinx_book_theme/static/jupyterbook.scss
@@ -2,15 +2,20 @@
 * Variables *
 *********************************************/
 // Breakpoints from Bootstrap: https://getbootstrap.com/docs/4.1/layout/overview/#responsive-breakpoints
+$breakpoint-xl: 1200px;
 $breakpoint-lg: 992px;
-$breakpoint-sm: 768px;
+$breakpoint-md: 768px;
+$breakpoint-sm: 576px;
 
 /*********************************************
 * Whole page *
 *********************************************/
 
+$content-max-width: 1450px;
+$topbar-height: 3.5em;
+
 .container-fluid {
-    max-width: 1450px;
+    max-width: $content-max-width;
 }
 
 body {
@@ -26,7 +31,7 @@ body {
 
 main {
     &.bd-content {
-        padding-top: 0px !important;
+        padding-top: $topbar-height !important;
         padding-bottom: 0px !important;
         overflow-y: hidden !important;
     }
@@ -93,7 +98,8 @@ div.cell {
 
 
 // Right sidebar CSS, largely copied from https://edwardtufte.github.io/tufte-css/
-@media (min-width: $breakpoint-lg) {
+// 992px is the L breakpoint in bootstrap
+@media (min-width: $breakpoint-md) {
     div.cell.tag_popout, div.cell.tag_sidebar, div.sidebar {
         float: right;
         clear: right;
@@ -116,7 +122,7 @@ div.cell {
     }
 }
 
-@media (max-width: $breakpoint-lg) {
+@media (max-width: $breakpoint-md) {
     div.cell.tag_popout, div.cell.tag_sidebar, div.sidebar {
         border-left: 3px solid #c3c3c3;
         margin: 1em;
@@ -167,23 +173,38 @@ dl.footnote {
 * Top Bar *
 *********************************************/
 .topbar {
+    max-width: $content-max-width;
+    margin: 0em auto 1em auto;
     padding-top: .75em;
     padding-bottom: .75em;
-    margin-bottom: 1em;
     background-color: white;
-    height: 3em;
+    height: 4em;
+    transition: left .2s;
 
-    button.navbar-toggler, .download-buttons-dropdown {
-        float: left;
-        height: 100%;
+    > div {
+        height: 2.5em;
+        top: 0px;
     }
 
-    button.topbarbtn {
-        margin: 0 .2em;
-        background-color: #5a5a5a;
+    .topbar-main {
+        button.navbar-toggler, .download-buttons-dropdown {
+            float: left;
+            height: 100%;
+        }
+    
+        button.topbarbtn {
+            margin: 0 .2em;
+            background-color: #5a5a5a;
+        }
     }
 }
 
+.bd-topbar-whitespace {
+    padding-right: none;
+    @media (max-width: 768px) {
+        display: none;
+    }
+}
 
 // Download buttons
 div.download-buttons-dropdown {
@@ -275,51 +296,43 @@ button.topbarbtn img {
     }
 }
 
-
-div.top {
-    display: none;
-}
-
-@media (max-width: $breakpoint-sm) {
-    div.top {
-        height: 3em;
-        display: block;
-    }
-
-    main button.navbar-toggler {
-        display: none;
-    }
-}
-
 /*********************************************
 * Table of Contents *
 *********************************************/
 
 .bd-toc {
-    top: 0px !important;
-    padding-top: 0px !important;
-    height: 3em;
-    overflow-y: auto;
+    padding: 0px !important;
+    overflow-y: hidden !important;
+    background: white;
     right: 0;
     z-index: 999;
+    transition: height .35s ease;
 
+    // By default the nav is hidden unless a few conditions are met
     nav {
-        opacity: .5;
-        height: 2em;
+        opacity: 0;
+        transition: opacity 0.2s ease; 
     }
 
-    &:hover nav {
-        opacity: 1;
-        height: auto;
+    // On really wide screens, we always show the nav
+    @media (min-width: 1200px) {
+        height: auto !important;
+        nav {
+            opacity: 1;
+        }
     }
 
+    // On hover or w/ a show calss, we show the TOC
+    &:hover, &.show {
+        height: auto !important;
+        nav {
+            opacity: 1;
+        }
+    }
 
     .tocsection {
-        padding-top: 1.5rem;
-
-        .bd-toc nav {
-            background-color: white;
-        }
+        padding-top: .5rem;
+        padding-bottom: .5rem;
     }
 }
 
@@ -329,11 +342,13 @@ div.top {
 .bd-sidebar  {
     top: 0px !important;
     overflow-y: auto;
-    opacity: 0.6;
     scrollbar-width: thin;
     height: 100vh !important;
-    transition: flex .2s ease 0s, height .35s ease, opacity 0.2s ease;
 
+    @media (min-width: 768px) {
+        opacity: 0.6;
+    }
+    
     &:hover {
         opacity: 1;
     }
@@ -351,10 +366,6 @@ div.top {
         padding-top: .5em;
     }
 
-    &.collapse:not(.show) {
-        display: none
-    }
-
     &.collapsing {
         border: none;
         overflow: hidden;
@@ -369,7 +380,24 @@ div.top {
     }
 }
 
-@media (max-width: $breakpoint-sm) {
+.site-navigation {
+    transition: flex .2s ease 0s, height .35s ease, opacity 0.2s ease;
+}
+
+#site-navigation {
+    @media (max-width: $breakpoint-md) {
+        position: fixed;
+        margin-top: $topbar-height;
+        z-index: 2000;
+        background: white;
+    }
+}
+
+@media (max-width: $breakpoint-md) {
+    div#main-content {
+        margin-top: $topbar-height;
+    }
+
     .bd-sidebar {
         height: 60vh !important;
         border-bottom: 3px solid #c3c3c3;
@@ -380,8 +408,12 @@ div.top {
     }
 }
 
-@media (min-width: $breakpoint-sm) {
-    #site-navigation.collapsing {
+@media (min-width: $breakpoint-md) {
+    .bd-sidebar {
+        z-index: 2000 !important;
+    }
+
+    .site-navigation.collapsing {
         flex: 0 0 0px;
         padding: 0;
     }
@@ -469,10 +501,12 @@ nav.bd-links {
         padding-left: 0;
     }
 
-    div#main-content {
-        margin-top: 5em;
-        width: 66% !important;
-        max-width: 66% !important;
+    .bd-content {
+        // Widen the main div since we won't have a TOC
+        div#main-content > div {
+            flex: 0 0 75%;
+            max-width: 75%;
+        }
     }
 
     h1, h2, h3, h4 {
@@ -515,7 +549,37 @@ nav.bd-links {
         min-width: 50% !important;
     }
 
-    div.bd-sidebar, div.prev-next-bottom, div.topbar, div.bd-toc {
+    div.bd-sidebar, div.prev-next-bottom {
         display: none;
+    }
+
+    div.topbar {
+        height: 0;
+        padding: 0;
+        position: inherit;  // So that TOC isn't printed on each page
+        
+        div.topbar-main {
+            opacity: 0;
+        }
+
+        // Grow and show the TOC on print
+        .bd-toc {
+            flex: 0 0 25%;
+            max-width: 25%;
+            height: auto !important;
+            // All 1st and 2nd items should be displayed
+            > nav, > nav > nav {
+                opacity: 1;
+                display: block;
+            }
+            
+            // No fancy styling for nav links
+            .nav-link.active {
+                font-weight: inherit;
+                color: inherit;
+                background-color: inherit;
+                border-left: inherit;
+            }
+        }
     }
 }

--- a/sphinx_book_theme/static/jupyterbook.scss
+++ b/sphinx_book_theme/static/jupyterbook.scss
@@ -171,6 +171,12 @@ dl.footnote {
     padding-bottom: .75em;
     margin-bottom: 1em;
     background-color: white;
+    height: 3em;
+
+    button.navbar-toggler, .download-buttons-dropdown {
+        float: left;
+        height: 100%;
+    }
 
     button.topbarbtn {
         margin: 0 .2em;
@@ -292,7 +298,21 @@ div.top {
 .bd-toc {
     top: 0px !important;
     padding-top: 0px !important;
+    height: 3em;
+    overflow-y: auto;
+    right: 0;
     z-index: 999;
+
+    nav {
+        opacity: .5;
+        height: 2em;
+    }
+
+    &:hover nav {
+        opacity: 1;
+        height: auto;
+    }
+
 
     .tocsection {
         padding-top: 1.5rem;

--- a/sphinx_book_theme/topbar.html
+++ b/sphinx_book_theme/topbar.html
@@ -1,21 +1,26 @@
 <div class="row topbar sticky-top">
-    <button id="navbar-toggler" class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navigation" aria-controls="navbar-menu" aria-expanded="true" aria-label="Toggle navigation" aria-controls="site-navigation">
-        <i class="fas fa-bars"></i>
-        <i class="fas fa-arrow-left"></i>
-    </button>
-    <div class="download-buttons-dropdown">
-        <button id="dropdown-button-trigger" class="btn btn-secondary topbarbtn"><i class="fas fa-download"></i></button>
-        <div class="download-buttons">
-            <!-- Download raw file -->
-            <a class="download-buttons" href="{{ pathto('_sources', 1) }}/{{ sourcename }}"><button type="button" class="btn btn-secondary topbarbtn">{{ page_source_suffix }}</button></a>
-            <!-- Download PDF via print -->
-            <button type="button" id="download-print" class="btn btn-secondary topbarbtn" onClick="window.print()">.pdf</button>
+    <div class="col">
+        <button id="navbar-toggler" class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navigation" aria-controls="navbar-menu" aria-expanded="true" aria-label="Toggle navigation" aria-controls="site-navigation">
+            <i class="fas fa-bars"></i>
+            <i class="fas fa-arrow-left"></i>
+        </button>
+        <div class="download-buttons-dropdown">
+            <button id="dropdown-button-trigger" class="btn btn-secondary topbarbtn"><i class="fas fa-download"></i></button>
+            <div class="download-buttons">
+                <!-- Download raw file -->
+                <a class="download-buttons" href="{{ pathto('_sources', 1) }}/{{ sourcename }}"><button type="button" class="btn btn-secondary topbarbtn">{{ page_source_suffix }}</button></a>
+                <!-- Download PDF via print -->
+                <button type="button" id="download-print" class="btn btn-secondary topbarbtn" onClick="window.print()">.pdf</button>
+            </div>
         </div>
+        {% if binder_url %}
+        <a class="binder-button" href="{{ binder_url }}"><button type="button" class="btn btn-secondary topbarbtn"><img class="binder-button-logo" src="{{ pathto('_static/images/logo_binder.svg', 1) }}" alt="Interact on binder">Binder</button></a>
+        {% endif %}
+        {% if jupyterhub_url %}
+        <a class="jupyterhub-button" href="{{ jupyterhub_url }}"><button type="button" class="btn btn-secondary topbarbtn"><img class="jupyterhub-button-logo" src="{{ pathto('_static/images/logo_jupyterhub.svg', 1) }}" alt="Interact on JupyterHub">JupyterHub</button></a>
+        {% endif %}
     </div>
-    {% if binder_url %}
-    <a class="binder-button" href="{{ binder_url }}"><button type="button" class="btn btn-secondary topbarbtn"><img class="binder-button-logo" src="{{ pathto('_static/images/logo_binder.svg', 1) }}" alt="Interact on binder">Binder</button></a>
-    {% endif %}
-    {% if jupyterhub_url %}
-    <a class="jupyterhub-button" href="{{ jupyterhub_url }}"><button type="button" class="btn btn-secondary topbarbtn"><img class="jupyterhub-button-logo" src="{{ pathto('_static/images/logo_jupyterhub.svg', 1) }}" alt="Interact on JupyterHub">JupyterHub</button></a>
-    {% endif %}
+    <div class="d-none d-md-block col-md-2 position-fixed bd-toc">
+        {%- include "docs-toc.html" %}
+    </div>
 </div>

--- a/sphinx_book_theme/topbar.html
+++ b/sphinx_book_theme/topbar.html
@@ -1,5 +1,5 @@
-<div class="row topbar fixed-top">
-    <div class="col-12 col-md-3 col-xl-3 bd-topbar-whitespace site-navigation show">
+<div class="row topbar fixed-top container-xl">
+    <div class="col-12 col-md-3 bd-topbar-whitespace site-navigation show">
     </div>
     <div class="col topbar-main">
         <button id="navbar-toggler" class="navbar-toggler" type="button" data-toggle="collapse" data-target=".site-navigation" aria-controls="navbar-menu" aria-expanded="true" aria-label="Toggle navigation" aria-controls="site-navigation">

--- a/sphinx_book_theme/topbar.html
+++ b/sphinx_book_theme/topbar.html
@@ -1,8 +1,11 @@
-<div class="row topbar sticky-top">
-    <div class="col">
-        <button id="navbar-toggler" class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navigation" aria-controls="navbar-menu" aria-expanded="true" aria-label="Toggle navigation" aria-controls="site-navigation">
+<div class="row topbar fixed-top">
+    <div class="col-12 col-md-3 col-xl-3 bd-topbar-whitespace site-navigation show">
+    </div>
+    <div class="col topbar-main">
+        <button id="navbar-toggler" class="navbar-toggler" type="button" data-toggle="collapse" data-target=".site-navigation" aria-controls="navbar-menu" aria-expanded="true" aria-label="Toggle navigation" aria-controls="site-navigation">
             <i class="fas fa-bars"></i>
             <i class="fas fa-arrow-left"></i>
+            <i class="fas fa-arrow-up"></i>
         </button>
         <div class="download-buttons-dropdown">
             <button id="dropdown-button-trigger" class="btn btn-secondary topbarbtn"><i class="fas fa-download"></i></button>
@@ -20,7 +23,7 @@
         <a class="jupyterhub-button" href="{{ jupyterhub_url }}"><button type="button" class="btn btn-secondary topbarbtn"><img class="jupyterhub-button-logo" src="{{ pathto('_static/images/logo_jupyterhub.svg', 1) }}" alt="Interact on JupyterHub">JupyterHub</button></a>
         {% endif %}
     </div>
-    <div class="d-none d-md-block col-md-2 position-fixed bd-toc">
+    <div class="d-none d-md-block col-md-2 bd-toc {{ show_if_no_sidebar() }}">
         {%- include "docs-toc.html" %}
     </div>
 </div>


### PR DESCRIPTION
This adds a bunch of extra "responsive UI" features.

* The right TOC now only shows up if there's no sidebar, or if the screen is wide enough
* It is also nested in the topbar instead of next to the main content
* This lets us use more screen real-estate for content until the screen is wider
* Also improves some of the printing CSS
* Finally, it re-works some of the CSS and HTML to accommodate the new pydata theme updates