### PR TITLE
adding support for opengraph tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,3 +57,4 @@ html_theme_options = {
     # "single_page": True
     # "number_toc_sections": True,
 }
+html_baseurl = "https://sphinx-book-theme.readthedocs.io/en/latest/"

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -219,3 +219,23 @@ html_theme_options = {
 ```
 
 Note: external links will be skipped in numbering.
+
+## Add metadata open graph tags to your site
+
+OpenGraph tags can be used to generate previews and descriptions of your
+website. These will be automatically generated based on your page's content
+and title. However, generating them requires knowing the full URL of your
+website ahead of time.
+
+To enable metadata tags for your documentation, use the following
+configuration in `conf.py`:
+
+```python
+html_baseurl = "https://<your-site-baseurl>"
+```
+
+For example, the value of this field for this documentation is:
+
+```python
+html_baseurl = "https://sphinx-book-theme.readthedocs.io/en/latest/"
+```

--- a/sphinx_book_theme/__init__.py
+++ b/sphinx_book_theme/__init__.py
@@ -197,6 +197,21 @@ def add_to_context(app, pagename, templatename, context, doctree):
     context["show_if_no_margin"] = show_if_no_margin
     context["nav_to_html_list"] = nav_to_html_list
 
+    # Add a shortened page text to the context using the sections text
+    if doctree:
+        description = ""
+        for section in doctree.traverse(nodes.section):
+            description += section.astext().replace("\n", " ")
+        description = description[:160]
+        context["page_description"] = description
+
+    # Absolute URLs for logo if `html_baseurl` is given
+    # pageurl will already be set by Sphinx if so
+    if app.config.html_baseurl and app.config.html_logo:
+        context["logourl"] = "/".join(
+            (app.config.html_baseurl.rstrip("/"), "_static/" + context["logo"])
+        )
+
 
 def compile_scss():
     path_css_folder = Path(__file__).parent.joinpath("static")

--- a/sphinx_book_theme/layout.html
+++ b/sphinx_book_theme/layout.html
@@ -5,6 +5,17 @@
 <!-- Put requirejs at the end so it's always after bootstrap -->
 <!-- TODO: remove this once https://github.com/pandas-dev/pydata-sphinx-theme/pull/149 is merged -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
+
+{% if pageurl %}
+<!-- Opengraph tags -->
+<meta property="og:url"         content="{{ pageurl }}" />
+<meta property="og:type"        content="article" />
+<meta property="og:title"       content="{% if title %}{{ title }}{% else %}{{ docstitle }}{% endif %}" />
+<meta property="og:description" content="{{ page_description }}" />
+{% if logourl %}<meta property="og:image"       content="{{ logourl }}" />{% endif %}
+
+<meta name="twitter:card" content="summary">
+{% endif %}
 {% endblock %}
 
 <!-- Docs TOC is "d-none d-xl-block col-xl-2" -->

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -44,6 +44,11 @@ def test_build_book(tmpdir):
     assert '<p class="margin-caption">My caption</p>' in index_text
     # Explicitly expanded sections are expanded when not active
     assert "Section 1 page1</a>" in index_text
+    # Opengraph should not be in the HTML because we have no baseurl specified
+    assert (
+        '<meta property="og:url"         content="https://blah.com/foo/section1/ntbk.html" />'  # noqa E501
+        not in ntbk_text
+    )
     rmtree(path_build)
 
     # Check navbar numbering
@@ -68,4 +73,20 @@ def test_build_book(tmpdir):
     run(cmd, cwd=path_tmp_base, check=True)
     ntbk_text = path_ntbk.read_text()
     assert 'id="site-navigation"' not in ntbk_text
+    rmtree(path_build)
+
+    # opengraph is generated when baseurl is given
+    baseurl = "https://blah.com/foo/"
+    path_logo = path_tests.parent.joinpath("docs", "_static", "logo.png")
+    cmd = cmd_base + ["-D", f"html_baseurl={baseurl}", "-D", f"html_logo={path_logo}"]
+    run(cmd, cwd=path_tmp_base, check=True)
+    ntbk_text = path_ntbk.read_text()
+    assert (
+        '<meta property="og:url"         content="https://blah.com/foo/section1/ntbk.html" />'  # noqa E501
+        in ntbk_text
+    )
+    assert (
+        '<meta property="og:image"       content="https://blah.com/foo/_static/logo.png" />'  # noqa E501
+        in ntbk_text
+    )
     rmtree(path_build)


### PR DESCRIPTION
It's a little bit hacky because the `html_baseurl` *must* be specified for this to work, but gets the job done. Unfortunately there's no way to dynamically update the meta tags so that they'd work with relative URLs

closes https://github.com/ExecutableBookProject/cli/issues/110